### PR TITLE
Fix discovering wrong root_func for Python3 (Ignores "{method 'disable' of '_lsprof.Profiler' objects}")

### DIFF
--- a/debug_toolbar_line_profiler/panel.py
+++ b/debug_toolbar_line_profiler/panel.py
@@ -14,6 +14,9 @@ import inspect
 from pstats import Stats
 from colorsys import hsv_to_rgb
 import os
+import sys
+
+PY3 = sys.version_info[0] == 3
 
 
 class DjangoDebugToolbarStats(Stats):
@@ -165,7 +168,9 @@ class ProfilingPanel(Panel):
         args = (request,) + view_args
         self.line_profiler = LineProfiler()
         self._unwrap_closure_and_profile(view_func)
-        if view_func.func_globals['__name__'] == 'django.views.generic.base':
+        view_func_name = view_func.__globals__['__name__'] if PY3 else \
+            view_func.func_globals['__name__'] 
+        if view_func_name == 'django.views.generic.base':
             for cell in view_func.func_closure:
                 target = cell.cell_contents
                 if inspect.isclass(target) and View in inspect.getmro(target):


### PR DESCRIPTION
**UPDATE: Use more robust information to find target func.**
(Based on pahaz's Python3 hotfix for testing)

Using Python 3.4.3 Homebrew version. Also tested with Python 2.7.6 Homebrew version.

There are two root_func candidates in stats either Python2 or Python3. One is the target view func, and another is Profiler.disable() . In Python2, Profiler.disable() is lined up at the end of the line. Contrastly in Python3, Profiler.disable() might be lined up at the end.
Profile will be lost when Profiler.disable() is lined up at the front.

There is a **race condition of stats dict**.

This must squash #4 