### PR TITLE
Support profiling optional function by signal, especially for Django REST Framwork

### DIFF
--- a/debug_toolbar_line_profiler/panel.py
+++ b/debug_toolbar_line_profiler/panel.py
@@ -15,6 +15,8 @@ from pstats import Stats
 from colorsys import hsv_to_rgb
 import os
 
+from debug_toolbar_line_profiler import signals
+
 
 class DjangoDebugToolbarStats(Stats):
     __root = None
@@ -172,6 +174,11 @@ class ProfilingPanel(Panel):
                     for name, value in inspect.getmembers(target):
                         if name[0] != '_' and inspect.ismethod(value):
                             self._unwrap_closure_and_profile(value)
+        signals.profiler_setup.send(sender=self,
+                                    profiler=self.line_profiler,
+                                    view_func=view_func,
+                                    view_args=view_args,
+                                    view_kwargs=view_kwargs)
         self.line_profiler.enable_by_count()
         out = self.profiler.runcall(view_func, *args, **view_kwargs)
         self.line_profiler.disable_by_count()

--- a/debug_toolbar_line_profiler/signals.py
+++ b/debug_toolbar_line_profiler/signals.py
@@ -1,0 +1,4 @@
+import django.dispatch
+
+
+profiler_setup = django.dispatch.Signal(providing_args=['profiler', 'view_func', 'view_args', 'view_kwargs'])


### PR DESCRIPTION
To support profiling non-standard but famous CBVs such as Django REST Framework, it needs entering optional function.

Usage:

```
from rest_framework.viewsets import ViewSet
from rest_framework.response import Response
from debug_toolbar_line_profiler import signals


class AViewSet(ViewSet):
    def list(self, request):
        return Response([])

    def retrieve(self, request, pk=None):
        return Response({})


def register_profile_views(sender, profiler, **kwargs):
    profiler.add_function(AViewSet.list)
    profiler.add_function(AViewSet.retrieve)


signals.profiler_setup.connect(register_profile_views,
                               dispatch_uid='register_profile_views')
```