### PR TITLE
Handle `<frozen importlib._bootstrap>` filepath

### DIFF
--- a/debug_toolbar_line_profiler/panel.py
+++ b/debug_toolbar_line_profiler/panel.py
@@ -76,7 +76,11 @@ class FunctionCall(object):
             if idx > -1:
                 file_name = file_name[(idx + 14):]
 
-            file_path, file_name = file_name.rsplit(os.sep, 1)
+            frozen = file_name.find('<frozen')
+            if frozen > -1:
+                file_path, file_name = ('', file_name)
+            else:
+                file_path, file_name = file_name.rsplit(os.sep, 1)
 
             return mark_safe(
                 '<span class="path">{0}/</span>'


### PR DESCRIPTION
prevents:
```
 .../site-packages/debug_toolbar_line_profiler/panel.py", line 80, in func_std_string
    file_path, file_name = file_name.rsplit(os.sep, 1)
ValueError: not enough values to unpack (expected 2, got 1)
```